### PR TITLE
Fixing display of icons on Canvas

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -235,7 +235,7 @@ module.exports = async (env) => [
             input.indexOf("fonts") === -1 &&
             input.indexOf("background-filter") === -1 &&
             input.indexOf("pficon") === -1,
-          type: "asset/source",
+          type: "asset",
         },
         {
           test: /\.(jpg|jpeg|png|gif)$/i,


### PR DESCRIPTION
The icons were loaded with the full source instead of rendering it because they were treated as `asset/source` by webpack instead of `asset`.
be careful, I have no idea why it was trying to load as `asset/source` previously and on which svg it can cause problems

![image](https://github.com/lordrip/vscode-kaoto/assets/1105127/36bea506-08f2-404a-b2f4-900f9c69c41e)
