### PR TITLE
Fix unit test compilation for OpenAPI import service

### DIFF
--- a/tsconfig.unit-tests.json
+++ b/tsconfig.unit-tests.json
@@ -3,6 +3,9 @@
   "compilerOptions": {
     "module": "CommonJS",
     "moduleResolution": "Node",
+    "paths": {
+      "@kaoto/camel-catalog/types": ["./node_modules/@kaoto/camel-catalog/dist/types/index.ts"]
+    },
     "strict": true,
     "experimentalDecorators": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
### Changes
Add paths mapping for @kaoto/camel-catalog/types in tsconfig.unit-tests.json. The package uses the exports field in package.json which isn't supported by moduleResolution: "Node". The paths mapping resolves the subpath export directly to the dist types.
